### PR TITLE
Add TLS verification option to deployment pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,3 +138,4 @@ jobs:
     with:
       operatorName: ${{ env.OPERATOR_NAME }}
       bundleImage: ${{ env.IMAGE_REGISTRY }}/${{ env.OPERATOR_BUNDLE_IMAGE_NAME }}:${{ needs.version.outputs.version }}
+      clusterLoginInsecure: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,6 +21,12 @@ on:
         default: false
         required: false
 
+      clusterLoginInsecure:
+        description: Skip TLS verification during login step into cluster.
+        type: boolean
+        default: false
+        required: false
+
   workflow_dispatch:
     inputs:
       operatorName:
@@ -41,6 +47,12 @@ on:
         default: false
         required: false
 
+      clusterLoginInsecure:
+        description: Skip TLS verification during login step into cluster.
+        type: boolean
+        default: false
+        required: false
+
 jobs:
   deploy:
     name: Deploy operator bundle
@@ -57,6 +69,7 @@ jobs:
           openshift_server_url: ${{ secrets.CLUSTER_API_URL }}
           openshift_token: ${{ secrets.CLUSTER_DEPLOYMENT_TOKEN }}
           namespace: ${{ secrets.CLUSTER_DEPLOYMENT_NAMESPACE }}
+          insecure_skip_tls_verify: ${{ inputs.clusterLoginInsecure }}
 
       - name: Deploy bundle to cluster
         working-directory: ./bin


### PR DESCRIPTION
Allow to skip TLS verification for current used cluster env.